### PR TITLE
fix plugin only reporting true for isNativeSupport

### DIFF
--- a/src/__tests__/plugin.ssr.test.js
+++ b/src/__tests__/plugin.ssr.test.js
@@ -1,0 +1,34 @@
+import { stylisPluginCssVariables } from '../plugin';
+
+describe('stylisPluginCssVariables', () => {
+	/* eslint-disable */
+	const baseArgs = {
+		context: 2,
+		content: '',
+		selectors: ['.font'],
+		parents: [],
+		line: 80,
+		column: 2,
+		length: 10,
+		type: 105,
+	};
+	/* eslint-enable */
+
+	test('doesnt blow up when rendering server side', () => {
+		// this should be in jest-env-node, so just gotta do the thing
+		const plugin = stylisPluginCssVariables();
+		const args = { ...baseArgs };
+
+		expect(typeof window).toBe('undefined');
+
+		const input = ['font-size: var( --font, 14px );'];
+
+		args.content = input.join('');
+
+		const result = plugin(...Object.values(args));
+
+		const compiled = ['font-size:14px;', 'font-size: var( --font, 14px );'];
+
+		expect(result).toBe(compiled.join(''));
+	});
+});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,7 +5,8 @@ import { hasVariable } from './utils';
 
 // Detects native CSS varialble support
 // https://github.com/jhildenbiddle/css-vars-ponyfill/blob/master/src/index.js
-let isNativeSupport = window?.CSS?.supports?.('(--a: 0)');
+let isNativeSupport =
+	typeof window !== 'undefined' && window?.CSS?.supports?.('(--a: 0)');
 
 /*
  * This plugin is for the stylis library. It's the CSS compiler used by

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,15 +5,7 @@ import { hasVariable } from './utils';
 
 // Detects native CSS varialble support
 // https://github.com/jhildenbiddle/css-vars-ponyfill/blob/master/src/index.js
-let isNativeSupport = true;
-/* istanbul ignore next */
-if (
-	typeof window !== 'undefined' &&
-	typeof window.CSS !== 'undefined' &&
-	typeof window.CSS.supports !== 'undefined'
-) {
-	isNativeSupport = window?.CSS?.supports('(--a: 0)');
-}
+let isNativeSupport = window?.CSS?.supports?.('(--a: 0)');
 
 /*
  * This plugin is for the stylis library. It's the CSS compiler used by
@@ -51,7 +43,6 @@ export function stylisPluginCssVariables(
 		type,
 	) => {
 		// Skip generating CSS variable fallbacks for supported browsers
-		/* istanbul ignore next */
 		if (skipSupportedBrowsers && isNativeSupport) return;
 
 		// Borrowed guard implementation from:

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,10 +46,12 @@ export function getRootPropertyValue(key) {
 		 * in our environment (JSDOM). In that case, we'll create a fresh
 		 * instance computedStyles on the root HTML element.
 		 */
-		rootStyles = window.getComputedStyle(document.documentElement);
+		rootStyles =
+			typeof window !== 'undefined' &&
+			window.getComputedStyle(document.documentElement);
 	}
 
-	return rootStyles?.getPropertyValue(key)?.trim();
+	return rootStyles?.getPropertyValue?.(key)?.trim();
 }
 
 /**


### PR DESCRIPTION
First off: love the plugin. I've been looking for something like this for a while now.

However: it doesn't work in IE11 without setting `skipSupportedBrowsers` to false (due to the `isNativeSupport` always being true if `window` or `window.CSS` or `window.CSS.supports` are undefined). This PR should fix it.

- added tests to prove it was doing what it should be doing
- IE11 (and JSDOM) have `window.CSS === undefined`
- when its undefined, the code never ran the `supports` check
- so the flag was always true
- you had to force it to run in all browsers to make it run in IE11
- this fixes that